### PR TITLE
Fix: Service Worker Syntax Error

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -7,8 +7,6 @@ import {
   summarizeText,
   generateReply,
   emojifyText,
-  generateReply,
-  emojifyText,
   generateContent
 } from "../lib/ai-service.js";
 


### PR DESCRIPTION
Removed duplicate imports of `generateReply` and `emojifyText` in `service-worker.js` that were causing registration failure.