### PR TITLE
Fix: Provider Not Defined

### DIFF
--- a/lib/ai-service.js
+++ b/lib/ai-service.js
@@ -59,6 +59,9 @@ export async function generateContent(prompt, options = {}) {
     throw new Error(`API key not configured for ${activeModel}`);
   }
 
+  // Resolve Provider Implementation
+  const provider = getProvider(activeModel);
+
   // Execute
   return await provider.generateContent(prompt, {
     apiKey,


### PR DESCRIPTION
Restored missing provider resolution logic in `lib/ai-service.js`. This fixes the 'provider is not defined' error when attempting to generate content.