### PR TITLE
Feat: Add Support for Gemini 2.0 & Groq Llama 3.2

### DIFF
--- a/lib/ai-providers.js
+++ b/lib/ai-providers.js
@@ -8,10 +8,11 @@ export const AI_PROVIDERS = {
     id: 'google',
     name: 'Google Gemini',
     keySetting: 'apiKey', // The storage key for this provider's API key
-    models: [
-      { id: 'gemini-1.5-flash', name: 'Gemini 1.5 Flash (Free Tier)' },
-      { id: 'gemini-1.5-pro', name: 'Gemini 1.5 Pro (Best Quality)' },
-      { id: 'gemini-2.0-flash', name: 'Gemini 2.0 Flash (Fastest)' }
+      { id: 'gemini-1.5-flash', name: 'Gemini 1.5 Flash' },
+      { id: 'gemini-1.5-pro', name: 'Gemini 1.5 Pro' },
+      { id: 'gemini-2.0-flash', name: 'Gemini 2.0 Flash' },
+      { id: 'gemini-2.0-flash-lite', name: 'Gemini 2.0 Flash Lite' },
+      { id: 'gemini-2.0-pro-exp', name: 'Gemini 2.0 Pro Experimental' }
     ]
   },
   groq: {
@@ -19,9 +20,14 @@ export const AI_PROVIDERS = {
     name: 'Groq',
     keySetting: 'groqApiKey',
     models: [
-      { id: 'groq-llama-3.3-70b', name: 'Llama 3.3 70B (Versatile)' },
-      { id: 'groq-llama-3.1-8b', name: 'Llama 3.1 8B (Instant)' },
-      { id: 'groq-mixtral', name: 'Mixtral 8x7b (Smart)' },
+      { id: 'groq-deepseek-r1-distill-llama-70b', name: 'DeepSeek R1 Distill Llama 70B' },
+      { id: 'groq-llama-3.3-70b', name: 'Llama 3.3 70B' },
+      { id: 'groq-llama-3.1-8b', name: 'Llama 3.1 8B' },
+      { id: 'groq-llama-3.2-90b-vision', name: 'Llama 3.2 90B Vision' },
+      { id: 'groq-llama-3.2-11b-vision', name: 'Llama 3.2 11B Vision' },
+      { id: 'groq-llama-3.2-3b', name: 'Llama 3.2 3B' },
+      { id: 'groq-llama-3.2-1b', name: 'Llama 3.2 1B' },
+      { id: 'groq-mixtral', name: 'Mixtral 8x7b' },
       { id: 'groq-gemma2', name: 'Gemma 2 9B' }
     ]
   }

--- a/lib/providers/groq.js
+++ b/lib/providers/groq.js
@@ -9,6 +9,11 @@ const GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
 const MODELS = {
   "groq-llama-3.3-70b": "llama-3.3-70b-versatile",
   "groq-llama-3.1-8b": "llama-3.1-8b-instant",
+  "groq-llama-3.2-90b-vision": "llama-3.2-90b-vision-preview",
+  "groq-llama-3.2-11b-vision": "llama-3.2-11b-vision-preview",
+  "groq-llama-3.2-3b": "llama-3.2-3b-preview",
+  "groq-llama-3.2-1b": "llama-3.2-1b-preview",
+  "groq-deepseek-r1-distill-llama-70b": "deepseek-r1-distill-llama-70b",
   "groq-mixtral": "mixtral-8x7b-32768",
   "groq-gemma2": "gemma2-9b-it",
 };


### PR DESCRIPTION
Added support for the latest AI models.

**New Models:**
- **Google Gemini**: Gemini 2.0 Flash Lite (Preview), Gemini 2.0 Pro (Experimental)
- **Groq**: DeepSeek R1 Distill 70B, Llama 3.2 Vision (90B, 11B), Llama 3.2 (3B, 1B)