### PR TITLE
Fix: Providers Syntax Error

### DIFF
--- a/lib/ai-providers.js
+++ b/lib/ai-providers.js
@@ -8,6 +8,7 @@ export const AI_PROVIDERS = {
     id: 'google',
     name: 'Google Gemini',
     keySetting: 'apiKey', // The storage key for this provider's API key
+    models: [
       { id: 'gemini-1.5-flash', name: 'Gemini 1.5 Flash' },
       { id: 'gemini-1.5-pro', name: 'Gemini 1.5 Pro' },
       { id: 'gemini-2.0-flash', name: 'Gemini 2.0 Flash' },


### PR DESCRIPTION
Restored the missing `models: [` array definition in `lib/ai-providers.js` that caused a syntax error.