### PR TITLE
Fix: Show Result in Same Overlay & Button Alignment

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -334,9 +334,13 @@ function replaceSelectedText(newText) {
 function showResultOverlay(payload) {
   const { action, original, result } = payload;
 
-  hideOverlay();
+  // Update existing overlay if present, otherwise create new
+  if (!overlay) {
+    overlay = createOverlayElement();
+    document.body.appendChild(overlay);
+  }
 
-  overlay = createOverlayElement();
+  // Update overlay content
   overlay.innerHTML = `
     <div class="omni-ai-overlay-header">
       <div class="omni-ai-overlay-title">
@@ -354,7 +358,6 @@ function showResultOverlay(payload) {
     </div>
   `;
 
-  document.body.appendChild(overlay);
   positionOverlay();
 
   // Event listeners

--- a/content/overlay.css
+++ b/content/overlay.css
@@ -145,6 +145,9 @@
 
 /* Buttons */
 .omni-ai-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   flex: 1;
   padding: 6px 12px;
   border: none;
@@ -152,6 +155,7 @@
   font-family: inherit;
   font-size: 12px;
   font-weight: 500;
+  line-height: 1;
   cursor: pointer;
   transition: all 0.15s ease;
 }


### PR DESCRIPTION
**Fixes:**

2. **Button Alignment**: Fixed Copy/Replace buttons with proper flexbox alignment
   - Added `display: flex`
   - Added `align-items: center`
   - Added `justify-content: center`
   - Added `line-height: 1` for consistent text alignment

**Flow:**
Menu → Loading (same overlay) → Result (same overlay) - completely seamless!