### PR TITLE
Refactor: Consolidate Groq Model Mapping

### DIFF
--- a/lib/ai-providers.js
+++ b/lib/ai-providers.js
@@ -21,15 +21,15 @@ export const AI_PROVIDERS = {
     name: 'Groq',
     keySetting: 'groqApiKey',
     models: [
-      { id: 'groq-deepseek-r1-distill-llama-70b', name: 'DeepSeek R1 Distill Llama 70B' },
-      { id: 'groq-llama-3.3-70b', name: 'Llama 3.3 70B' },
-      { id: 'groq-llama-3.1-8b', name: 'Llama 3.1 8B' },
-      { id: 'groq-llama-3.2-90b-vision', name: 'Llama 3.2 90B Vision' },
-      { id: 'groq-llama-3.2-11b-vision', name: 'Llama 3.2 11B Vision' },
-      { id: 'groq-llama-3.2-3b', name: 'Llama 3.2 3B' },
-      { id: 'groq-llama-3.2-1b', name: 'Llama 3.2 1B' },
-      { id: 'groq-mixtral', name: 'Mixtral 8x7b' },
-      { id: 'groq-gemma2', name: 'Gemma 2 9B' }
+      { id: 'groq-deepseek-r1-distill-llama-70b', name: 'DeepSeek R1 Distill Llama 70B', apiModel: 'deepseek-r1-distill-llama-70b' },
+      { id: 'groq-llama-3.3-70b', name: 'Llama 3.3 70B', apiModel: 'llama-3.3-70b-versatile' },
+      { id: 'groq-llama-3.1-8b', name: 'Llama 3.1 8B', apiModel: 'llama-3.1-8b-instant' },
+      { id: 'groq-llama-3.2-90b-vision', name: 'Llama 3.2 90B Vision', apiModel: 'llama-3.2-90b-vision-preview' },
+      { id: 'groq-llama-3.2-11b-vision', name: 'Llama 3.2 11B Vision', apiModel: 'llama-3.2-11b-vision-preview' },
+      { id: 'groq-llama-3.2-3b', name: 'Llama 3.2 3B', apiModel: 'llama-3.2-3b-preview' },
+      { id: 'groq-llama-3.2-1b', name: 'Llama 3.2 1B', apiModel: 'llama-3.2-1b-preview' },
+      { id: 'groq-mixtral', name: 'Mixtral 8x7b', apiModel: 'mixtral-8x7b-32768' },
+      { id: 'groq-gemma2', name: 'Gemma 2 9B', apiModel: 'gemma2-9b-it' }
     ]
   }
 };
@@ -43,6 +43,21 @@ export function getProviderByModel(modelId) {
   for (const provider of Object.values(AI_PROVIDERS)) {
     if (provider.models.find(m => m.id === modelId)) {
       return provider;
+    }
+  }
+  return null;
+}
+
+/**
+ * Get API model name for a given model ID
+ * @param {string} modelId 
+ * @returns {string|null} API model name or null
+ */
+export function getApiModelName(modelId) {
+  for (const provider of Object.values(AI_PROVIDERS)) {
+    const model = provider.models.find(m => m.id === modelId);
+    if (model) {
+      return model.apiModel || modelId; // Fallback to modelId if no apiModel specified
     }
   }
   return null;

--- a/lib/providers/groq.js
+++ b/lib/providers/groq.js
@@ -3,20 +3,11 @@
  * Handles interaction with Groq API
  */
 
+import { getApiModelName } from '../ai-providers.js';
+
 const GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
 
-// Model mapping
-const MODELS = {
-  "groq-llama-3.3-70b": "llama-3.3-70b-versatile",
-  "groq-llama-3.1-8b": "llama-3.1-8b-instant",
-  "groq-llama-3.2-90b-vision": "llama-3.2-90b-vision-preview",
-  "groq-llama-3.2-11b-vision": "llama-3.2-11b-vision-preview",
-  "groq-llama-3.2-3b": "llama-3.2-3b-preview",
-  "groq-llama-3.2-1b": "llama-3.2-1b-preview",
-  "groq-deepseek-r1-distill-llama-70b": "deepseek-r1-distill-llama-70b",
-  "groq-mixtral": "mixtral-8x7b-32768",
-  "groq-gemma2": "gemma2-9b-it",
-};
+
 
 /**
  * Generate content using Groq
@@ -30,7 +21,7 @@ export async function generateContent(prompt, config) {
     throw new Error("Groq API key not configured");
   }
 
-  const groqModel = MODELS[model] || "llama-3.3-70b-versatile";
+  const groqModel = getApiModelName(model) || "llama-3.3-70b-versatile";
 
   const body = {
     messages: [


### PR DESCRIPTION
**Problem:**
Duplicate model declarations between `ai-providers.js` and `groq.js` - violates DRY principle.

**Solution:**
- Added `apiModel` property to each Groq model in `AI_PROVIDERS`
- Created `getApiModelName(modelId)` helper function
- Removed duplicate `MODELS` constant from `groq.js`
- Updated `groq.js` to use `getApiModelName()` for model resolution

**Benefits:**
- Single source of truth for model configuration
- Easier to add/update models (only one place to change)
- Reduced code duplication
- Better maintainability