### PR TITLE
UI: Move Save Settings Button Below Fields

### DIFF
--- a/settings.css
+++ b/settings.css
@@ -537,30 +537,35 @@ input:focus + .slider {
   border-color: rgba(255, 255, 255, 0.15);
 }
 
-/* Footer */
-.footer {
+/* Save Actions Area */
+.save-actions {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: var(--spacing-md);
+  gap: var(--spacing-sm);
   margin-top: var(--spacing-2xl);
-  padding-top: var(--spacing-xl);
-  border-top: 1px solid var(--border-color);
+  padding-bottom: var(--spacing-2xl);
 }
 
 .save-btn {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: var(--spacing-sm);
-  padding: var(--spacing-md) var(--spacing-xl);
+  padding: 14px 24px;
   background: var(--accent-gradient);
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   color: white;
   font-family: var(--font-family);
-  font-size: 14px;
-  font-weight: 500;
+  font-size: 15px;
+  font-weight: 600;
   cursor: pointer;
   transition: all var(--transition-fast);
+}
+
+.save-btn.full-width {
+  width: 100%;
 }
 
 .save-btn:hover {
@@ -576,7 +581,9 @@ input:focus + .slider {
   font-size: 13px;
   color: var(--success);
   opacity: 0;
+  height: 20px;
   transition: opacity var(--transition-normal);
+  font-weight: 500;
 }
 
 .save-status.visible {

--- a/settings.html
+++ b/settings.html
@@ -457,30 +457,28 @@
             </div>
           </div>
         </section>
+        <!-- Save Actions -->
+        <div class="save-actions">
+          <button id="saveBtn" class="save-btn full-width">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path
+                d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"
+              ></path>
+              <polyline points="17 21 17 13 7 13 7 21"></polyline>
+              <polyline points="7 3 7 8 15 8"></polyline>
+            </svg>
+            __MSG_settings_save__
+          </button>
+          <span id="saveStatus" class="save-status"></span>
+        </div>
       </main>
-
-      <!-- Footer -->
-      <footer class="footer">
-        <button id="saveBtn" class="save-btn">
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <path
-              d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"
-            ></path>
-            <polyline points="17 21 17 13 7 13 7 21"></polyline>
-            <polyline points="7 3 7 8 15 8"></polyline>
-          </svg>
-          __MSG_settings_save__
-        </button>
-
-        <span id="saveStatus" class="save-status"></span>
-      </footer>
     </div>
 
     <script src="settings.js" type="module"></script>


### PR DESCRIPTION
Closes #51.

**Changes:**
- Relocated the Save Settings button from the fixed footer to a new `.save-actions` container at the end of the settings page.
- Applied `full-width` styling to the button.
- Cleaned up footer styles in `settings.css`.
- Increased button padding and font weight for a more prominent "Call to Action" feel.
- Positioned the save status message below the full-width button.