### PR TITLE
Fix floating icon border radius

### DIFF
--- a/content/overlay.css
+++ b/content/overlay.css
@@ -335,6 +335,8 @@
   justify-content: center;
   width: 22px;
   height: 22px;
+  padding: 0;
+  box-sizing: border-box;
   background: linear-gradient(135deg, #8b5cf6 0%, #06b6d4 100%);
   border: none;
   border-radius: 50%;


### PR DESCRIPTION
Closes #66

## Changes
- Added `padding: 0` to `.omni-ai-quick-btn` to prevent button shape distortion.
- Ensures `border-radius: 50%` renders a true circle at 22px size.