### PR TITLE
feat: limit result content height

### DIFF
--- a/content/overlay.css
+++ b/content/overlay.css
@@ -128,6 +128,7 @@
   padding: 12px 16px;
   overflow-y: auto;
   flex: 1;
+  max-height: 400px; /* Reasonable limit for long content */
 }
 
 .omni-ai-result {


### PR DESCRIPTION
Closes #70. Limits the content area height to 400px with scrolling for better UX on long results.