### PR TITLE
The error `Ollama API Error (403): Forbidden`

### DIFF
--- a/lib/providers/ollama.js
+++ b/lib/providers/ollama.js
@@ -50,12 +50,6 @@ export async function generateContent(prompt, config) {
     });
 
     if (!response.ok) {
-      if (response.status === 403) {
-        throw new Error(
-          'Ollama connection forbidden (403). Please restart Ollama with OLLAMA_ORIGINS="*" environment variable.',
-        );
-      }
-
       const errorText = await response.text();
       throw new Error(
         `Ollama API Error (${response.status}): ${errorText || response.statusText}`,


### PR DESCRIPTION
…al Ollama instance is blocking the connection from the browser extension due to CORS security policies.

I have updated the extension to give a more helpful error message for this specific case.

**To fix this, you must restart Ollama with the `OLLAMA_ORIGINS` environment variable set to allow external origins.**

### How to fix:

1.  **Stop Ollama**: Quit the Ollama app or stop the service.
2.  **Restart with Environment Variable**:

    **Mac/Linux:** ```bash OLLAMA_ORIGINS="*" ollama serve ```

    **Windows (PowerShell):** ```powershell $env:OLLAMA_ORIGINS="*"; ollama serve ```

3.  **Validate Again**: Go back to the extension settings and click "Validate Configuration". It should now succeed.