### PR TITLE
fix(popup): preserve draft and page context across popup closes

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -529,5 +529,13 @@
   "include_page_context": {
     "message": "Inhalt dieser Seite als Kontext einbeziehen",
     "description": "Checkbox label to include page content"
+  },
+  "popup_page_context_included": {
+    "message": "Der Seiteninhalt wurde hinzugefügt und wird als Kontext für diese Unterhaltung verwendet.",
+    "description": "System message shown after page content is attached to the popup conversation context"
+  },
+  "include_page_context_locked_hint": {
+    "message": "Der Seitenkontext ist für diese Unterhaltung gesperrt. Starte einen neuen Chat, um ihn zu ändern.",
+    "description": "Tooltip when include page context checkbox is locked during an active conversation"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -529,5 +529,13 @@
   "include_page_context": {
     "message": "Include this page's content as context for AI responses",
     "description": "Checkbox label to include page content in chat context"
+  },
+  "popup_page_context_included": {
+    "message": "Page content has been included and will be used as context for this conversation.",
+    "description": "System message shown after page content is attached to the popup conversation context"
+  },
+  "include_page_context_locked_hint": {
+    "message": "Page context is locked for this conversation. Start a new chat to change it.",
+    "description": "Tooltip when include page context checkbox is locked during an active conversation"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -529,5 +529,13 @@
   "include_page_context": {
     "message": "Incluir el contenido de esta página como contexto",
     "description": "Checkbox label to include page content"
+  },
+  "popup_page_context_included": {
+    "message": "El contenido de la página se ha incluido y se usará como contexto para esta conversación.",
+    "description": "System message shown after page content is attached to the popup conversation context"
+  },
+  "include_page_context_locked_hint": {
+    "message": "El contexto de la página está bloqueado para esta conversación. Inicia un chat nuevo para cambiarlo.",
+    "description": "Tooltip when include page context checkbox is locked during an active conversation"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -529,5 +529,13 @@
   "include_page_context": {
     "message": "Inclure le contenu de cette page comme contexte",
     "description": "Checkbox label to include page content"
+  },
+  "popup_page_context_included": {
+    "message": "Le contenu de la page a été inclus et sera utilisé comme contexte pour cette conversation.",
+    "description": "System message shown after page content is attached to the popup conversation context"
+  },
+  "include_page_context_locked_hint": {
+    "message": "Le contexte de la page est verrouillé pour cette conversation. Démarrez une nouvelle discussion pour le modifier.",
+    "description": "Tooltip when include page context checkbox is locked during an active conversation"
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -529,5 +529,13 @@
   "include_page_context": {
     "message": "Includi il contenuto di questa pagina come contesto",
     "description": "Checkbox label to include page content"
+  },
+  "popup_page_context_included": {
+    "message": "Il contenuto della pagina è stato incluso e verrà usato come contesto per questa conversazione.",
+    "description": "System message shown after page content is attached to the popup conversation context"
+  },
+  "include_page_context_locked_hint": {
+    "message": "Il contesto della pagina è bloccato per questa conversazione. Avvia una nuova chat per modificarlo.",
+    "description": "Tooltip when include page context checkbox is locked during an active conversation"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -529,5 +529,13 @@
   "include_page_context": {
     "message": "このページのコンテンツをコンテキストとして含める",
     "description": "Checkbox label to include page content"
+  },
+  "popup_page_context_included": {
+    "message": "ページ内容が追加され、この会話のコンテキストとして使用されます。",
+    "description": "System message shown after page content is attached to the popup conversation context"
+  },
+  "include_page_context_locked_hint": {
+    "message": "この会話ではページコンテキストが固定されています。変更するには新しいチャットを開始してください。",
+    "description": "Tooltip when include page context checkbox is locked during an active conversation"
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -529,5 +529,13 @@
   "include_page_context": {
     "message": "이 페이지의 내용을 컨텍스트로 포함",
     "description": "Checkbox label to include page content"
+  },
+  "popup_page_context_included": {
+    "message": "페이지 콘텐츠가 포함되었으며 이 대화의 컨텍스트로 사용됩니다.",
+    "description": "System message shown after page content is attached to the popup conversation context"
+  },
+  "include_page_context_locked_hint": {
+    "message": "이 대화에서는 페이지 컨텍스트가 고정되었습니다. 변경하려면 새 채팅을 시작하세요.",
+    "description": "Tooltip when include page context checkbox is locked during an active conversation"
   }
 }

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -529,5 +529,13 @@
   "include_page_context": {
     "message": "Incluir conteúdo desta página como contexto",
     "description": "Checkbox label to include page content"
+  },
+  "popup_page_context_included": {
+    "message": "O conteúdo da página foi incluído e será usado como contexto para esta conversa.",
+    "description": "System message shown after page content is attached to the popup conversation context"
+  },
+  "include_page_context_locked_hint": {
+    "message": "O contexto da página está bloqueado para esta conversa. Inicie um novo chat para alterá-lo.",
+    "description": "Tooltip when include page context checkbox is locked during an active conversation"
   }
 }

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -529,5 +529,13 @@
   "include_page_context": {
     "message": "Sử dụng nội dung trang này làm ngữ cảnh",
     "description": "Checkbox label to include page content"
+  },
+  "popup_page_context_included": {
+    "message": "Nội dung trang đã được thêm và sẽ được dùng làm ngữ cảnh cho cuộc hội thoại này.",
+    "description": "System message shown after page content is attached to the popup conversation context"
+  },
+  "include_page_context_locked_hint": {
+    "message": "Ngữ cảnh trang đã bị khóa cho cuộc hội thoại này. Hãy bắt đầu cuộc trò chuyện mới để thay đổi.",
+    "description": "Tooltip when include page context checkbox is locked during an active conversation"
   }
 }

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -529,5 +529,13 @@
   "include_page_context": {
     "message": "将此页面内容作为上下文",
     "description": "Checkbox label to include page content"
+  },
+  "popup_page_context_included": {
+    "message": "页面内容已加入，并将作为本次对话的上下文使用。",
+    "description": "System message shown after page content is attached to the popup conversation context"
+  },
+  "include_page_context_locked_hint": {
+    "message": "该页面上下文在本次对话中已锁定。请开启新对话以更改。",
+    "description": "Tooltip when include page context checkbox is locked during an active conversation"
   }
 }

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -387,6 +387,12 @@ body {
   color: var(--text-primary);
 }
 
+.checkbox-label.is-locked {
+  pointer-events: none;
+  opacity: 0.8;
+  cursor: not-allowed;
+}
+
 .checkbox-label input[type="checkbox"] {
   display: none;
 }
@@ -421,6 +427,10 @@ body {
   border-width: 0 2px 2px 0;
   transform: rotate(45deg);
   margin-bottom: 2px;
+}
+
+.checkbox-label input[type="checkbox"]:disabled ~ .label-text {
+  opacity: 0.9;
 }
 
 .label-text {
@@ -681,6 +691,18 @@ body {
   border: 1px solid rgba(139, 92, 246, 0.2);
   color: var(--text-primary);
   border-bottom-left-radius: 4px;
+}
+
+.chat-bubble.system {
+  align-self: center;
+  max-width: 100%;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px dashed var(--border-color);
+  color: var(--text-secondary);
+  font-size: 11px;
+  text-align: center;
+  border-radius: 12px;
+  padding: 8px 12px;
 }
 
 .chat-bubble.error {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -13,6 +13,9 @@ const elements = {
   askBtn: document.getElementById("askBtn"),
   settingsBtn: document.getElementById("settingsBtn"),
   includePageContext: document.getElementById("includePageContext"),
+  includePageContextLabel: document.querySelector(
+    ".context-toggle .checkbox-label",
+  ),
 
   // Status
   status: document.getElementById("status"),
@@ -40,6 +43,16 @@ const elements = {
 let isProcessing = false;
 let currentUser = null;
 let chatHistory = [];
+let conversationPageContext = null;
+let isPageContextLocked = false;
+
+const STORAGE_KEYS = {
+  chatHistory: "popupChatHistory",
+  pageContextSession: "popupPageContextSession",
+  draftState: "popupDraftState",
+};
+
+let draftSaveTimer = null;
 
 /**
  * Initialize popup
@@ -51,6 +64,7 @@ async function init() {
   setupEventListeners();
   await loadAuthState();
   await loadChatHistory();
+  await loadDraftState();
   focusInput();
 }
 
@@ -112,6 +126,8 @@ function setupEventListeners() {
       handleQuickAsk();
     }
   });
+  elements.quickAskInput.addEventListener("input", scheduleSaveDraftState);
+  elements.includePageContext?.addEventListener("change", scheduleSaveDraftState);
 
   // Settings
   elements.settingsBtn.addEventListener("click", openSettings);
@@ -128,6 +144,15 @@ function setupEventListeners() {
   document.addEventListener("click", (e) => {
     if (!elements.userSection.contains(e.target)) {
       closeUserDropdown();
+    }
+  });
+
+  // Extension action popup closes when it loses focus (e.g. Win+Space IME switch).
+  // Persist draft state to reduce disruption.
+  window.addEventListener("beforeunload", saveDraftState);
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      saveDraftState();
     }
   });
 }
@@ -248,6 +273,108 @@ function getDefaultAvatar(name) {
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 
+function getPageContextNoticeMessage() {
+  return (
+    i18n.getMessage("popup_page_context_included") ||
+    "Page content has been included and will be used as context for this conversation."
+  );
+}
+
+function applyPageContextCheckboxState() {
+  const checkbox = elements.includePageContext;
+  if (!checkbox) return;
+
+  const label = elements.includePageContextLabel;
+  if (isPageContextLocked) {
+    checkbox.checked = true;
+    checkbox.disabled = true;
+    if (label) {
+      label.classList.add("is-locked");
+      label.title =
+        i18n.getMessage("include_page_context_locked_hint") ||
+        "Page context is locked for this conversation. Start a new chat to change it.";
+    }
+  } else {
+    checkbox.disabled = false;
+    if (label) {
+      label.classList.remove("is-locked");
+      label.removeAttribute("title");
+    }
+  }
+}
+
+async function fetchCurrentPageContent() {
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id) return null;
+
+    const response = await chrome.tabs.sendMessage(tab.id, {
+      type: "GET_PAGE_CONTENT",
+    });
+
+    if (!response?.success || !response?.content) {
+      return null;
+    }
+
+    return {
+      text: response.content,
+      title: response.title || "",
+      url: response.url || "",
+    };
+  } catch (e) {
+    console.warn("[Omni AI] Failed to get page content:", e);
+    return null;
+  }
+}
+
+async function loadDraftState() {
+  try {
+    const data = await chrome.storage.local.get(STORAGE_KEYS.draftState);
+    const draft = data[STORAGE_KEYS.draftState];
+    if (!draft || typeof draft !== "object") return;
+
+    if (elements.quickAskInput && typeof draft.query === "string") {
+      elements.quickAskInput.value = draft.query;
+    }
+
+    if (
+      elements.includePageContext &&
+      !isPageContextLocked &&
+      typeof draft.includePageContext === "boolean"
+    ) {
+      elements.includePageContext.checked = draft.includePageContext;
+    }
+
+    applyPageContextCheckboxState();
+  } catch (e) {
+    console.error("Failed to load draft state:", e);
+  }
+}
+
+function scheduleSaveDraftState() {
+  if (draftSaveTimer) {
+    clearTimeout(draftSaveTimer);
+  }
+  draftSaveTimer = setTimeout(() => {
+    saveDraftState();
+    draftSaveTimer = null;
+  }, 120);
+}
+
+async function saveDraftState() {
+  try {
+    const includeChecked =
+      isPageContextLocked || !!elements.includePageContext?.checked;
+    await chrome.storage.local.set({
+      [STORAGE_KEYS.draftState]: {
+        query: elements.quickAskInput?.value || "",
+        includePageContext: includeChecked,
+      },
+    });
+  } catch (e) {
+    console.error("Failed to save draft state:", e);
+  }
+}
 
 // ============================================
 // Chat Logic
@@ -258,12 +385,69 @@ function getDefaultAvatar(name) {
  */
 async function loadChatHistory() {
   try {
-    const { popupChatHistory = [] } = await chrome.storage.local.get("popupChatHistory");
-    chatHistory = popupChatHistory;
+    const data = await chrome.storage.local.get([
+      STORAGE_KEYS.chatHistory,
+      STORAGE_KEYS.pageContextSession,
+    ]);
+
+    chatHistory = Array.isArray(data[STORAGE_KEYS.chatHistory])
+      ? data[STORAGE_KEYS.chatHistory]
+      : [];
+
+    const storedContextSession = data[STORAGE_KEYS.pageContextSession];
+    if (
+      storedContextSession?.locked &&
+      storedContextSession?.pageContent?.text
+    ) {
+      isPageContextLocked = true;
+      conversationPageContext = storedContextSession.pageContent;
+    } else {
+      isPageContextLocked = false;
+      conversationPageContext = null;
+    }
+
+    // Backward compatibility: recover context from legacy hidden system message.
+    if (!conversationPageContext) {
+      const legacyContextMessage = [...chatHistory].reverse().find((msg) => {
+        return (
+          msg?.role === "system" &&
+          msg?.hidden &&
+          typeof msg?.content === "string" &&
+          msg.content.startsWith('Page context from "')
+        );
+      });
+
+      if (legacyContextMessage) {
+        const legacyMatch = legacyContextMessage.content.match(
+          /^Page context from "(.*)":\n([\s\S]*)$/,
+        );
+
+        if (legacyMatch?.[2]) {
+          conversationPageContext = {
+            text: legacyMatch[2],
+            title: legacyContextMessage.pageTitle || legacyMatch[1] || "",
+            url: legacyContextMessage.pageUrl || "",
+          };
+          isPageContextLocked = true;
+        }
+      }
+    }
+
+    // Keep old hidden context entries out of visible chat.
+    chatHistory = chatHistory.filter((msg) => !msg?.hidden);
+
+    applyPageContextCheckboxState();
     renderChatHistory();
+
+    if (isPageContextLocked) {
+      await saveChatHistory();
+    }
   } catch (e) {
     console.error("Failed to load history:", e);
     chatHistory = [];
+    conversationPageContext = null;
+    isPageContextLocked = false;
+    applyPageContextCheckboxState();
   }
 }
 
@@ -272,7 +456,18 @@ async function loadChatHistory() {
  */
 async function saveChatHistory() {
   try {
-    await chrome.storage.local.set({ popupChatHistory: chatHistory });
+    const contextSession =
+      isPageContextLocked && conversationPageContext?.text
+        ? {
+            locked: true,
+            pageContent: conversationPageContext,
+          }
+        : null;
+
+    await chrome.storage.local.set({
+      [STORAGE_KEYS.chatHistory]: chatHistory,
+      [STORAGE_KEYS.pageContextSession]: contextSession,
+    });
   } catch (e) {
     console.error("Failed to save history:", e);
   }
@@ -286,14 +481,16 @@ function renderChatHistory() {
   
   // Clear container but keep empty state
   elements.chatContainer.innerHTML = '';
-  
-  if (chatHistory.length === 0) {
+
+  const visibleMessages = chatHistory.filter((msg) => !msg?.hidden);
+
+  if (visibleMessages.length === 0) {
     if (elements.emptyState) {
         elements.chatContainer.appendChild(elements.emptyState);
         elements.emptyState.style.display = 'flex';
     }
   } else {
-    chatHistory.forEach(msg => appendBubble(msg.role, msg.content, false));
+    visibleMessages.forEach(msg => appendBubble(msg.role, msg.content, false));
     scrollToBottom();
   }
 }
@@ -357,10 +554,24 @@ function scrollToBottom() {
  * Handle new chat
  */
 async function handleNewChat() {
-    chatHistory = [];
-    await saveChatHistory();
-    renderChatHistory();
-    focusInput();
+  chatHistory = [];
+  conversationPageContext = null;
+  isPageContextLocked = false;
+
+  if (elements.quickAskInput) {
+    elements.quickAskInput.value = "";
+    elements.quickAskInput.style.height = "auto";
+  }
+
+  if (elements.includePageContext) {
+    elements.includePageContext.checked = false;
+  }
+  applyPageContextCheckboxState();
+
+  await saveChatHistory();
+  await saveDraftState();
+  renderChatHistory();
+  focusInput();
 }
 
 /**
@@ -371,55 +582,58 @@ async function handleQuickAsk() {
   if (!query || isProcessing) return;
 
   setProcessing(true);
-  
-  const includeContext = elements.includePageContext?.checked || false;
-  let pageContent = null;
-  
-  if (includeContext) {
-    try {
-      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      if (tab?.id) {
-        const response = await chrome.tabs.sendMessage(tab.id, { type: "GET_PAGE_CONTENT" });
-        if (response?.success && response.content) {
-          pageContent = {
-            text: response.content,
-            title: response.title,
-            url: response.url
-          };
-        }
-      }
-    } catch (e) {
-      console.warn("[Omni AI] Failed to get page content:", e);
+
+  const shouldIncludeContext =
+    isPageContextLocked || elements.includePageContext?.checked || false;
+  let justIncludedPageContext = false;
+
+  if (shouldIncludeContext && !conversationPageContext) {
+    const fetchedPageContent = await fetchCurrentPageContent();
+    if (fetchedPageContent?.text) {
+      conversationPageContext = fetchedPageContent;
+      isPageContextLocked = true;
+      justIncludedPageContext = true;
+      applyPageContextCheckboxState();
     }
   }
-  
+
   chatHistory.push({ role: "user", content: query });
   appendBubble("user", query);
-  
-  if (pageContent) {
+
+  if (justIncludedPageContext) {
+    const contextNotice = getPageContextNoticeMessage();
     chatHistory.push({
       role: "system",
-      content: `Page context from "${pageContent.title}":\n${pageContent.text}`,
-      hidden: true,
-      pageTitle: pageContent.title,
-      pageUrl: pageContent.url
+      content: contextNotice,
+      kind: "page_context_notice",
     });
+    appendBubble("system", contextNotice);
   }
-  
-  saveChatHistory();
+
+  await saveChatHistory();
 
   elements.quickAskInput.value = "";
   elements.quickAskInput.style.height = 'auto';
+  await saveDraftState();
 
   showTypingIndicator();
 
   const contextParts = [];
-  
-  if (pageContent) {
-    contextParts.push(`Current page content from "${pageContent.title}":\n${pageContent.text}`);
+
+  if (conversationPageContext?.text) {
+    const pageTitle =
+      conversationPageContext.title ||
+      i18n.getMessage("popup_context") ||
+      "Current Page";
+    contextParts.push(
+      `Current page content from "${pageTitle}":\n${conversationPageContext.text}`,
+    );
   }
-  
-  const contextMsgs = chatHistory.filter(m => m.role !== 'system').slice(0, -1).slice(-10);
+
+  const contextMsgs = chatHistory
+    .filter((m) => m.role === "user" || m.role === "ai")
+    .slice(0, -1)
+    .slice(-10);
   contextMsgs.forEach(m => {
     contextParts.push(`${m.role === 'user' ? 'User' : 'AI'}: ${m.content}`);
   });
@@ -443,7 +657,7 @@ async function handleQuickAsk() {
       
       chatHistory.push({ role: "ai", content: answer });
       appendBubble("ai", answer);
-      saveChatHistory();
+      await saveChatHistory();
 
     } else {
       updateStatus(i18n.getMessage("status_error"), "error");


### PR DESCRIPTION
This PR improves the popup chat flow when the Chrome extension popup is closed unexpectedly (for example, when switching input method with Win+Space while using iBus Bamboo).

The popup cannot prevent Chrome from auto-closing on focus loss, so this change focuses on preserving conversation continuity and preventing user data loss.

What changed:
- Added draft persistence for popup input text and include-context checkbox state (`popupDraftState`).
- Auto-saves draft state on input/checkbox changes, beforeunload, and visibilitychange.
- Restores draft state when popup reopens.
- Added persistent conversation page-context session storage (`popupPageContextSession`) so context remains available across popup reopen events.
- When page context is first included, the UI now shows a concise system notice instead of injecting full page content into visible chat messages.
- Keeps page-context checkbox locked (checked + disabled) for the active conversation.
- Resets lock/state only when user starts a new chat.
- Added localized strings for the new system notice and lock tooltip across all supported locales (de, en, es, fr, it, ja, ko, pt, vi, zh).

Why:
- Avoid losing typed input and context when popup closes due to system hotkeys.
- Keep chat UI clean while still using page content as AI context for follow-up responses.
- Enforce consistent per-conversation context behavior.

Validation:
- npm test -- --runInBand (all suites passing)
- Locale JSON validation for all _locales/*/messages.json

Notes:
- The Chrome action popup close-on-focus-loss behavior is platform/Chrome controlled and is not directly overridable by popup scripts.
