### PR TITLE
fix(ai-service): keep rephrase output simple and close to source

### DIFF
--- a/lib/ai-service.js
+++ b/lib/ai-service.js
@@ -122,9 +122,10 @@ export async function improveText(
 ) {
   const systemPrompt = getSystemPrompt(action, context, options);
   const fullPrompt = `${systemPrompt}\n\n---\n\nOriginal text:\n${text}\n\n---\n\nImproved text:`;
+  const defaultTemperature = action === "rephrase" ? 0.15 : 0.3;
 
   return await generateContent(fullPrompt, {
-    temperature: 0.3,
+    temperature: defaultTemperature,
     ...options,
   });
 }
@@ -285,12 +286,16 @@ function getSystemPrompt(action, context, options = {}) {
     tone: `Rewrite the text with a ${tone} tone while keeping the same meaning. This is for ${contextDesc}.`,
     concise: `Make the text more concise by removing unnecessary words and redundancy while preserving all key information. This is for ${contextDesc}.`,
     expand: `Expand the text by adding more detail, context, and depth while maintaining the original message. This is for ${contextDesc}.`,
-    rephrase: `Rephrase the text using different words and sentence structures while keeping the same meaning. This is for ${contextDesc}.`,
+    rephrase: `Rephrase the text using simple, everyday words while keeping the same meaning. Stay close to the original phrasing and sentence flow. This is for ${contextDesc}.`,
   };
 
   const basePrompt = actionPrompts[action] || actionPrompts.grammar;
+  const rephraseRules =
+    action === "rephrase"
+      ? "\n- For rephrase: use common words used in daily communication, not fancy or rare vocabulary\n- For rephrase: keep names, numbers, technical terms, and key facts unchanged\n- For rephrase: make minimal necessary changes; do not add new ideas or details\n- For rephrase: keep sentence length and tone close to the original unless clarity requires a small change"
+      : "";
 
-  return `You are a professional writing assistant.\n\n${basePrompt}\n\nRules:\n- Output ONLY the improved text, nothing else\n- Do not include explanations or notes\n- DETECT the language of the original text and output in the SAME language\n- Do NOT translate the text unless explicitly asked\n- STRICTLY preserve all original formatting (paragraphs, lists, indentation) exactly. Do not merge lines.`;
+  return `You are a professional writing assistant.\n\n${basePrompt}\n\nRules:\n- Output ONLY the improved text, nothing else\n- Do not include explanations or notes\n- DETECT the language of the original text and output in the SAME language\n- Do NOT translate the text unless explicitly asked\n- STRICTLY preserve all original formatting (paragraphs, lists, indentation) exactly. Do not merge lines.${rephraseRules}`;
 }
 
 // ============================================

--- a/tests/lib/ai-service.test.js
+++ b/tests/lib/ai-service.test.js
@@ -114,6 +114,23 @@ describe("AI Service", () => {
     expect(callArgs[0]).toContain("Original text:\nBad text");
   });
 
+  it("rephrase prefers simple words and uses lower default temperature", async () => {
+    store["geminiApiKey"] = "key";
+    mockProvider.generateContent.mockResolvedValue("Rephrased Text");
+
+    const result = await improveText("Complicated sentence", "rephrase", "chat");
+
+    expect(result).toBe("Rephrased Text");
+    const callArgs = mockProvider.generateContent.mock.calls[0];
+    expect(callArgs[0]).toContain("simple, everyday words");
+    expect(callArgs[0]).toContain("not fancy or rare vocabulary");
+    expect(callArgs[1]).toEqual(
+      expect.objectContaining({
+        temperature: 0.15,
+      }),
+    );
+  });
+
   it("throws error if API key is missing", async () => {
     // No keys in store
     await expect(generateContent("Test")).rejects.toThrow(


### PR DESCRIPTION
This PR improves the **Rephrase** behavior to keep output closer to the original text and avoid overly fancy vocabulary.

## What changed
- Updated the `rephrase` action prompt to explicitly prefer simple, everyday words.
- Added stronger rephrase-specific guardrails:
  - avoid rare/fancy word substitutions,
  - keep names, numbers, technical terms, and key facts unchanged,
  - make only minimal necessary edits,
  - stay close to original sentence flow and tone.
- Lowered the default temperature for `rephrase` from `0.3` to `0.15` to reduce stylistic variance.

## Why
Users reported that rephrased outputs sometimes introduced complex wording and drifted from the source tone/content. This change makes rephrasing more practical for daily communication and more faithful to the original intent.

## Tests
- Added a unit test to verify:
  - the rephrase prompt includes simple-language constraints,
  - the default temperature for rephrase is `0.15`.
- Ran: `npm test -- --runInBand` (all tests passing).
